### PR TITLE
Make brace openings similar to Unity coding standards

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -5,7 +5,8 @@
 		"body": [
 			"using UnityEngine;",
 			"",
-			"public class ${TM_FILENAME_BASE} : MonoBehaviour {",
+			"public class ${TM_FILENAME_BASE} : MonoBehaviour",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -16,8 +17,10 @@
 		"body": [
 			"using UnityEngine;",
 			"",
-			"public class ${TM_FILENAME_BASE} : StateMachineBehaviour {",
-			"\tpublic override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex) {",
+			"public class ${TM_FILENAME_BASE} : StateMachineBehaviour",
+			"{",
+			"\tpublic override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)",
+			"\t{",
 			"\t\t$0",
 			"\t}",
 			"}"
@@ -30,7 +33,8 @@
 			"using UnityEngine;",
 			"using UnityEngine.Networking;",
 			"",
-			"public class ${TM_FILENAME_BASE} : NetworkBehaviour {",
+			"public class ${TM_FILENAME_BASE} : NetworkBehaviour",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -42,7 +46,8 @@
 			"using UnityEngine;",
 			"",
 			"[CreateAssetMenu(fileName = \"${1:${TM_FILENAME_BASE}}\", menuName = \"${2:${TM_FILEPATH/.*\\\\(.*)\\\\Assets\\\\.*/${1}/}/${TM_FILENAME_BASE}}\", order = ${3:0})]",
-			"public class ${TM_FILENAME_BASE} : ScriptableObject {",
+			"public class ${TM_FILENAME_BASE} : ScriptableObject",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -55,8 +60,10 @@
 			"using UnityEditor;",
 			"",
 			"[CustomEditor(typeof(${1:${TM_FILENAME_BASE/(.*)Editor/${1}/}}))]",
-			"public class ${TM_FILENAME_BASE} : Editor {",
-			"\tpublic override void OnInspectorGUI() {",
+			"public class ${TM_FILENAME_BASE} : Editor",
+			"{",
+			"\tpublic override void OnInspectorGUI()",
+			"\t{",
 			"\t\tbase.OnInspectorGUI();",
 			"\t\t$0",
 			"\t}",
@@ -72,29 +79,35 @@
 			"using UnityEditorInternal;",
 			"",
 			"[CustomEditor(typeof(${1:${TM_FILENAME_BASE/(.*)Editor/${1}/}}))]",
-			"public class ${TM_FILENAME_BASE} : Editor {",
+			"public class ${TM_FILENAME_BASE} : Editor",
+			"{",
 			"\tprivate SerializedProperty _property;",
 			"\tprivate ReorderableList _list;",
 			"",
-			"\tprivate void OnEnable() {",
+			"\tprivate void OnEnable()",
+			"\t{",
 			"\t\t_property = serializedObject.FindProperty(\"${2}\");",
-			"\t\t_list = new ReorderableList(serializedObject, _property, true, true, true, true) {",
+			"\t\t_list = new ReorderableList(serializedObject, _property, true, true, true, true)",
+			"\t\t{",
 			"\t\t\tdrawHeaderCallback = DrawListHeader,",
 			"\t\t\tdrawElementCallback = DrawListElement",
 			"\t\t};",
 			"\t}",
 			"",
-			"\tprivate void DrawListHeader(Rect rect) {",
+			"\tprivate void DrawListHeader(Rect rect)",
+			"\t{",
 			"\t\tGUI.Label(rect, \"${2}\");",
 			"\t}",
 			"",
-			"\tprivate void DrawListElement(Rect rect, int index, bool isActive, bool isFocused) {",
+			"\tprivate void DrawListElement(Rect rect, int index, bool isActive, bool isFocused)",
+			"\t{",
 			"\t\tvar item = _property.GetArrayElementAtIndex(index);",
 			"\t\tEditorGUI.PropertyField(rect, item);",
 			"\t\t$0",
 			"\t}",
 			"",
-			"\tpublic override void OnInspectorGUI() {",
+			"\tpublic override void OnInspectorGUI()",
+			"\t{",
 			"\t\tserializedObject.Update();",
 			"\t\tEditorGUILayout.Space();",
 			"\t\t_list.DoLayoutList();",
@@ -110,16 +123,19 @@
 			"using UnityEngine;",
 			"using UnityEditor;",
 			"",
-			"public class ${TM_FILENAME_BASE} : EditorWindow {",
+			"public class ${TM_FILENAME_BASE} : EditorWindow",
+			"{",
 			"",
 			"\t[MenuItem(\"${1:${TM_FILEPATH/.*\\\\(.*)\\\\Assets\\\\.*/${1}/}/${TM_FILENAME_BASE/(.*)Editor/${1}/}}\")]",
-			"\tprivate static void ShowWindow() {",
+			"\tprivate static void ShowWindow()",
+			"\t{",
 			"\t\tvar window = GetWindow<${TM_FILENAME_BASE}>();",
 			"\t\twindow.titleContent = new GUIContent(\"${2:${TM_FILENAME_BASE/(.*)Editor/${1}/}}\");",
 			"\t\twindow.Show();",
 			"\t}",
 			"",
-			"\tprivate void OnGUI() {",
+			"\tprivate void OnGUI()",
+			"\t{",
 			"\t\t$0",
 			"\t}",
 			"}"
@@ -133,8 +149,10 @@
 			"using UnityEditor;",
 			"",
 			"[CustomPropertyDrawer(typeof(${1:${TM_FILENAME_BASE/(.*)Drawer/${1}/}}))]",
-			"public class ${TM_FILENAME_BASE}: PropertyDrawer {",
-			"\tpublic override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {",
+			"public class ${TM_FILENAME_BASE}: PropertyDrawer",
+			"\t{",
+			"\tpublic override void OnGUI(Rect position, SerializedProperty property, GUIContent label)",
+			"\t{",
 			"\t\t$0",
 			"\t}",
 			"}"
@@ -147,14 +165,17 @@
 			"using UnityEngine;",
 			"using UnityEditor;",
 			"",
-			"public class ${TM_FILENAME_BASE}: ScriptableWizard {",
+			"public class ${TM_FILENAME_BASE}: ScriptableWizard",
+			"{",
 			"",
 			"\t[MenuItem(\"${1:${TM_FILEPATH/.*\\\\(.*)\\\\Assets\\\\.*/${1}/}/${TM_FILENAME_BASE/(.*)Wizard/${1}/}}\")]",
-			"\tprivate static void MenuEntryCall() {",
+			"\tprivate static void MenuEntryCall()",
+			"\t{",
 			"\t\tDisplayWizard<${TM_FILENAME_BASE}>(\"${2:Title}\");",
 			"\t}",
 			"",
-			"\tprivate void OnWizardCreate() {",
+			"\tprivate void OnWizardCreate()",
+			"\t{",
 			"\t\t$0",
 			"\t}",
 			"}"
@@ -164,7 +185,8 @@
 		"prefix": "Awake()",
 		"description": "Awake is called when the script instance is being loaded.",
 		"body": [
-			"private void Awake() {",
+			"private void Awake()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -173,7 +195,8 @@
 		"prefix": "FixedUpdate()",
 		"description": "This function is called every fixed framerate frame, if the MonoBehaviour is enabled.",
 		"body": [
-			"private void FixedUpdate() {",
+			"private void FixedUpdate()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -182,7 +205,8 @@
 		"prefix": "LateUpdate()",
 		"description": "LateUpdate is called every frame, if the Behaviour is enabled. It is called after all Update functions have been called.",
 		"body": [
-			"private void LateUpdate() {",
+			"private void LateUpdate()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -191,7 +215,8 @@
 		"prefix": "OnAnimatorIK(int)",
 		"description": "Callback for setting up animation IK (inverse kinematics).",
 		"body": [
-			"private void OnAnimatorIK(int layerIndex) {",
+			"private void OnAnimatorIK(int layerIndex)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -200,7 +225,8 @@
 		"prefix": "OnAnimatorMove()",
 		"description": "Callback for processing animation movements for modifying root motion.",
 		"body": [
-			"private void OnAnimatorMove() {",
+			"private void OnAnimatorMove()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -209,7 +235,8 @@
 		"prefix": "OnApplicationFocus(bool)",
 		"description": "Callback sent to all game objects when the player gets or loses focus.",
 		"body": [
-			"private void OnApplicationFocus(bool focusStatus) {",
+			"private void OnApplicationFocus(bool focusStatus)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -218,7 +245,8 @@
 		"prefix": "OnApplicationPause(bool)",
 		"description": "Callback sent to all game objects when the player pauses.",
 		"body": [
-			"private void OnApplicationPause(bool pauseStatus) {",
+			"private void OnApplicationPause(bool pauseStatus)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -227,7 +255,8 @@
 		"prefix": "OnApplicationQuit()",
 		"description": "Callback sent to all game objects before the application is quit.",
 		"body": [
-			"private void OnApplicationQuit() {",
+			"private void OnApplicationQuit()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -236,7 +265,8 @@
 		"prefix": "OnAudioFilterRead(float[], int)",
 		"description": "If OnAudioFilterRead is implemented, Unity will insert a custom filter into the audio DSP chain.",
 		"body": [
-			"private void OnAudioFilterRead(float[] data, int channels) {",
+			"private void OnAudioFilterRead(float[] data, int channels)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -245,7 +275,8 @@
 		"prefix": "OnBecameInvisible()",
 		"description": "OnBecameInvisible is called when the renderer is no longer visible by any camera.",
 		"body": [
-			"private void OnBecameInvisible() {",
+			"private void OnBecameInvisible()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -254,7 +285,8 @@
 		"prefix": "OnBecameVisible()",
 		"description": "OnBecameVisible is called when the renderer became visible by any camera.",
 		"body": [
-			"private void OnBecameVisible() {",
+			"private void OnBecameVisible()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -263,7 +295,8 @@
 		"prefix": "OnCollisionEnter(Collision)",
 		"description": "OnCollisionEnter is called when this collider/rigidbody has begun\n touching another rigidbody/collider.",
 		"body": [
-			"private void OnCollisionEnter(Collision other) {",
+			"private void OnCollisionEnter(Collision other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -272,7 +305,8 @@
 		"prefix": "OnCollisionEnter2D(Collision2D)",
 		"description": "Sent when an incoming collider makes contact with this object's collider (2D physics only).",
 		"body": [
-			"private void OnCollisionEnter2D(Collision2D other) {",
+			"private void OnCollisionEnter2D(Collision2D other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -281,7 +315,8 @@
 		"prefix": "OnCollisionExit(Collision)",
 		"description": "OnCollisionExit is called when this collider/rigidbody has stopped touching another rigidbody/collider.",
 		"body": [
-			"private void OnCollisionExit(Collision other) {",
+			"private void OnCollisionExit(Collision other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -290,7 +325,8 @@
 		"prefix": "OnCollisionExit2D(Collision2D)",
 		"description": "Sent when a collider on another object stops touching this object's collider (2D physics only).",
 		"body": [
-			"private void OnCollisionExit2D(Collision2D other) {",
+			"private void OnCollisionExit2D(Collision2D other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -299,7 +335,8 @@
 		"prefix": "OnCollisionStay(Collision)",
 		"description": "OnCollisionStay is called once per frame for every collider/rigidbody that is touching rigidbody/collider.",
 		"body": [
-			"private void OnCollisionStay(Collision other) {",
+			"private void OnCollisionStay(Collision other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -308,7 +345,8 @@
 		"prefix": "OnCollisionStay2D(Collision2D)",
 		"description": "Sent each frame where a collider on another object is touching this object's collider (2D physics only).",
 		"body": [
-			"private void OnCollisionStay2D(Collision2D other) {",
+			"private void OnCollisionStay2D(Collision2D other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -317,7 +355,8 @@
 		"prefix": "OnConnectedToServer()",
 		"description": "Called on the client when you have successfully connected to a server.",
 		"body": [
-			"private void OnConnectedToServer() {",
+			"private void OnConnectedToServer()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -326,7 +365,8 @@
 		"prefix": "OnControllerColliderHit(ControllerColliderHit)",
 		"description": "OnControllerColliderHit is called when the controller hits a collider while performing a Move.",
 		"body": [
-			"private void OnControllerColliderHit(ControllerColliderHit hit) {",
+			"private void OnControllerColliderHit(ControllerColliderHit hit)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -335,7 +375,8 @@
 		"prefix": "OnDestroy()",
 		"description": "This function is called when the MonoBehaviour will be destroyed.",
 		"body": [
-			"private void OnDestroy() {",
+			"private void OnDestroy()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -344,7 +385,8 @@
 		"prefix": "OnDisable()",
 		"description": "This function is called when the behaviour becomes disabled or inactive.",
 		"body": [
-			"private void OnDisable() {",
+			"private void OnDisable()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -353,7 +395,8 @@
 		"prefix": "OnDisconnectedFromServer(NetworkDisconnection)",
 		"description": "Called on the client when the connection was lost or you disconnected from the server.",
 		"body": [
-			"private void OnDisconnectedFromServer(NetworkDisconnection info) {",
+			"private void OnDisconnectedFromServer(NetworkDisconnection info)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -362,7 +405,8 @@
 		"prefix": "OnDrawGizmos()",
 		"description": "Callback to draw gizmos that are pickable and always drawn.",
 		"body": [
-			"private void OnDrawGizmos() {",
+			"private void OnDrawGizmos()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -371,7 +415,8 @@
 		"prefix": "OnDrawGizmosSelected()",
 		"description": "Callback to draw gizmos only if the object is selected.",
 		"body": [
-			"private void OnDrawGizmosSelected() {",
+			"private void OnDrawGizmosSelected()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -380,7 +425,8 @@
 		"prefix": "OnEnable()",
 		"description": "This function is called when the object becomes enabled and active.",
 		"body": [
-			"private void OnEnable() {",
+			"private void OnEnable()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -389,7 +435,8 @@
 		"prefix": "OnFailedToConnect(NetworkConnectionError)",
 		"description": "Called on the client when a connection attempt fails for some reason.",
 		"body": [
-			"private void OnFailedToConnect(NetworkConnectionError error) {",
+			"private void OnFailedToConnect(NetworkConnectionError error)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -398,7 +445,8 @@
 		"prefix": "OnFailedToConnectToMasterServer(NetworkConnectionError)",
 		"description": "Called on clients or servers when there is a problem connecting to the MasterServer.",
 		"body": [
-			"private void OnFailedToConnectToMasterServer(NetworkConnectionError error) {",
+			"private void OnFailedToConnectToMasterServer(NetworkConnectionError error)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -407,7 +455,8 @@
 		"prefix": "OnGUI()",
 		"description": "OnGUI is called for rendering and handling GUI events.",
 		"body": [
-			"private void OnGUI() {",
+			"private void OnGUI()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -416,7 +465,8 @@
 		"prefix": "OnJointBreak(float)",
 		"description": "Called when a joint attached to the same game object broke.",
 		"body": [
-			"private void OnJointBreak(float breakForce) {",
+			"private void OnJointBreak(float breakForce)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -425,7 +475,8 @@
 		"prefix": "OnJointBreak2D(Joint2D)",
 		"description": "Called when a Joint2D attached to the same game object breaks.",
 		"body": [
-			"private void OnJointBreak2D(Joint2D brokenJoint) {",
+			"private void OnJointBreak2D(Joint2D brokenJoint)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -434,7 +485,8 @@
 		"prefix": "OnMasterServerEvent(MasterServerEvent)",
 		"description": "Called on clients or servers when reporting events from the MasterServer.",
 		"body": [
-			"private void OnMasterServerEvent(MasterServerEvent msEvent) {",
+			"private void OnMasterServerEvent(MasterServerEvent msEvent)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -443,7 +495,8 @@
 		"prefix": "OnMouseDown()",
 		"description": "OnMouseDown is called when the user has pressed the mouse button while over the GUIElement or Collider.",
 		"body": [
-			"private void OnMouseDown() {",
+			"private void OnMouseDown()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -452,7 +505,8 @@
 		"prefix": "OnMouseDrag()",
 		"description": "OnMouseDrag is called when the user has clicked on a GUIElement or Collider and is still holding down the mouse.",
 		"body": [
-			"private void OnMouseDrag() {",
+			"private void OnMouseDrag()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -461,7 +515,8 @@
 		"prefix": "OnMouseEnter()",
 		"description": "Called when the mouse enters the GUIElement or Collider.",
 		"body": [
-			"private void OnMouseEnter() {",
+			"private void OnMouseEnter()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -470,7 +525,8 @@
 		"prefix": "OnMouseExit()",
 		"description": "Called when the mouse is not any longer over the GUIElement or Collider.",
 		"body": [
-			"private void OnMouseExit() {",
+			"private void OnMouseExit()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -479,7 +535,8 @@
 		"prefix": "OnMouseOver()",
 		"description": "Called every frame while the mouse is over the GUIElement or Collider.",
 		"body": [
-			"private void OnMouseOver() {",
+			"private void OnMouseOver()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -488,7 +545,8 @@
 		"prefix": "OnMouseUp()",
 		"description": "OnMouseUp is called when the user has released the mouse button.",
 		"body": [
-			"private void OnMouseUp() {",
+			"private void OnMouseUp()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -497,7 +555,8 @@
 		"prefix": "OnMouseUpAsButton()",
 		"description": "OnMouseUpAsButton is only called when the mouse is released over the same GUIElement or Collider as it was pressed.",
 		"body": [
-			"private void OnMouseUpAsButton() {",
+			"private void OnMouseUpAsButton()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -506,7 +565,8 @@
 		"prefix": "OnNetworkInstantiate(NetworkMessageInfo)",
 		"description": "Called on objects which have been network instantiated with Network.Instantiate.",
 		"body": [
-			"private void OnNetworkInstantiate(NetworkMessageInfo info) {",
+			"private void OnNetworkInstantiate(NetworkMessageInfo info)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -515,7 +575,8 @@
 		"prefix": "OnParticleCollision(GameObject)",
 		"description": "OnParticleCollision is called when a particle hits a collider.",
 		"body": [
-			"private void OnParticleCollision(GameObject other) {",
+			"private void OnParticleCollision(GameObject other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -524,7 +585,8 @@
 		"prefix": "OnParticleSystemStopped()",
 		"description": "OnParticleSystemStopped is called when all particles in the system have died, and no new particles will be born. New particles cease to be created either after Stop is called, or when the duration property of a non-looping system has been exceeded.",
 		"body": [
-			"private void OnParticleSystemStopped() {",
+			"private void OnParticleSystemStopped()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -533,7 +595,8 @@
 		"prefix": "OnParticleTrigger()",
 		"description": "OnParticleTrigger is called when any particles in a particle system meet the conditions in the trigger module.",
 		"body": [
-			"private void OnParticleTrigger() {",
+			"private void OnParticleTrigger()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -542,7 +605,8 @@
 		"prefix": "OnPlayerConnected(NetworkPlayer)",
 		"description": "Called on the server whenever a new player has successfully connected.",
 		"body": [
-			"private void OnPlayerConnected(NetworkPlayer player) {",
+			"private void OnPlayerConnected(NetworkPlayer player)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -551,7 +615,8 @@
 		"prefix": "OnPlayerDisconnected(NetworkPlayer)",
 		"description": "Called on the server whenever a player disconnected from the server.",
 		"body": [
-			"private void OnPlayerDisconnected(NetworkPlayer player) {",
+			"private void OnPlayerDisconnected(NetworkPlayer player)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -560,7 +625,8 @@
 		"prefix": "OnPostRender()",
 		"description": "OnPostRender is called after a camera finishes rendering the scene.",
 		"body": [
-			"private void OnPostRender() {",
+			"private void OnPostRender()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -569,7 +635,8 @@
 		"prefix": "OnPreCull()",
 		"description": "OnPreCull is called before a camera culls the scene.",
 		"body": [
-			"private void OnPreCull() {",
+			"private void OnPreCull()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -578,7 +645,8 @@
 		"prefix": "OnPreRender()",
 		"description": "OnPreRender is called before a camera starts rendering the scene.",
 		"body": [
-			"private void OnPreRender() {",
+			"private void OnPreRender()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -587,7 +655,8 @@
 		"prefix": "OnRenderImage(RenderTexture, RenderTexture)",
 		"description": "OnRenderImage is called after all rendering is complete to render image.",
 		"body": [
-			"private void OnRenderImage(RenderTexture src, RenderTexture dest) {",
+			"private void OnRenderImage(RenderTexture src, RenderTexture dest)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -596,7 +665,8 @@
 		"prefix": "OnRenderObject()",
 		"description": "OnRenderObject is called after camera has rendered the scene.",
 		"body": [
-			"private void OnRenderObject() {",
+			"private void OnRenderObject()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -605,7 +675,8 @@
 		"prefix": "OnSerializeNetworkView(BitStream, NetworkMessageInfo)",
 		"description": "Used to customize synchronization of variables in a script watched by a network view.",
 		"body": [
-			"private void OnSerializeNetworkView(BitStream stream, NetworkMessageInfo info) {",
+			"private void OnSerializeNetworkView(BitStream stream, NetworkMessageInfo info)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -614,7 +685,8 @@
 		"prefix": "OnServerInitialized()",
 		"description": "Called on the server whenever a Network.InitializeServer was invoked and has completed.",
 		"body": [
-			"private void OnServerInitialized() {",
+			"private void OnServerInitialized()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -623,7 +695,8 @@
 		"prefix": "OnTransformChildrenChanged()",
 		"description": "Called when the list of children of the transform of the GameObject has changed.",
 		"body": [
-			"private void OnTransformChildrenChanged() {",
+			"private void OnTransformChildrenChanged()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -632,7 +705,8 @@
 		"prefix": "OnTransformParentChanged()",
 		"description": "Called when the parent property of the transform of the GameObject has changed.",
 		"body": [
-			"private void OnTransformParentChanged() {",
+			"private void OnTransformParentChanged()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -641,7 +715,8 @@
 		"prefix": "OnTriggerEnter(Collider)",
 		"description": "OnTriggerEnter is called when the Collider other enters the trigger.",
 		"body": [
-			"private void OnTriggerEnter(Collider other) {",
+			"private void OnTriggerEnter(Collider other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -650,7 +725,8 @@
 		"prefix": "OnTriggerEnter2D(Collider2D)",
 		"description": "Sent when another object enters a trigger collider attached to this object (2D physics only).",
 		"body": [
-			"private void OnTriggerEnter2D(Collider2D other) {",
+			"private void OnTriggerEnter2D(Collider2D other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -659,7 +735,8 @@
 		"prefix": "OnTriggerExit(Collider)",
 		"description": "OnTriggerExit is called when the Collider other has stopped touching the trigger.",
 		"body": [
-			"private void OnTriggerExit(Collider other) {",
+			"private void OnTriggerExit(Collider other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -668,7 +745,8 @@
 		"prefix": "OnTriggerExit2D(Collider2D)",
 		"description": "Sent when another object leaves a trigger collider attached to this object (2D physics only).",
 		"body": [
-			"private void OnTriggerExit2D(Collider2D other) {",
+			"private void OnTriggerExit2D(Collider2D other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -677,7 +755,8 @@
 		"prefix": "OnTriggerStay(Collider)",
 		"description": "OnTriggerStay is called once per frame for every Collider other that is touching the trigger.",
 		"body": [
-			"private void OnTriggerStay(Collider other) {",
+			"private void OnTriggerStay(Collider other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -686,7 +765,8 @@
 		"prefix": "OnTriggerStay2D(Collider2D)",
 		"description": "Sent each frame where another object is within a trigger collider attached to this object (2D physics only).",
 		"body": [
-			"private void OnTriggerStay2D(Collider2D other) {",
+			"private void OnTriggerStay2D(Collider2D other)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -695,7 +775,8 @@
 		"prefix": "OnValidate()",
 		"description": "Called when the script is loaded or a value is changed in the inspector (Called in the editor only).",
 		"body": [
-			"private void OnValidate() {",
+			"private void OnValidate()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -704,7 +785,8 @@
 		"prefix": "OnWillRenderObject()",
 		"description": "OnWillRenderObject is called for each camera if the object is visible.",
 		"body": [
-			"private void OnWillRenderObject() {",
+			"private void OnWillRenderObject()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -713,7 +795,8 @@
 		"prefix": "Reset()",
 		"description": "Reset is called when the user hits the Reset button in the Inspector's context menu or when adding the component the first time.",
 		"body": [
-			"private void Reset() {",
+			"private void Reset()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -722,7 +805,8 @@
 		"prefix": "Start()",
 		"description": "Start is called on the frame when a script is enabled just before any of the Update methods is called the first time.",
 		"body": [
-			"private void Start() {",
+			"private void Start()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -731,7 +815,8 @@
 		"prefix": "Update()",
 		"description": "Update is called every frame, if the MonoBehaviour is enabled.",
 		"body": [
-			"private void Update() {",
+			"private void Update()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -740,7 +825,8 @@
 		"prefix": "OnStateEnter()",
 		"description": "Called on the first Update frame when a statemachine evaluate this state.",
 		"body": [
-			"private void OnStateEnter(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex) {",
+			"private void OnStateEnter(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -749,7 +835,8 @@
 		"prefix": "OnStateExit()",
 		"description": "Called on the last update frame when a statemachine evaluate this state.",
 		"body": [
-			"private void OnStateExit(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex) {",
+			"private void OnStateExit(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -758,7 +845,8 @@
 		"prefix": "OnStateIK()",
 		"description": "Called right after MonoBehaviour.OnAnimatorIK.",
 		"body": [
-			"private void OnStateIK(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex) {",
+			"private void OnStateIK(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -767,7 +855,8 @@
 		"prefix": "OnStateMove()",
 		"description": "Called right after MonoBehaviour.OnAnimatorMove.",
 		"body": [
-			"private void OnStateMove(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex) {",
+			"private void OnStateMove(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -776,7 +865,8 @@
 		"prefix": "OnStateUpdate()",
 		"description": "Called on the first Update frame when a statemachine evaluate this state.",
 		"body": [
-			"private void OnStateUpdate(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex) {",
+			"private void OnStateUpdate(Animator animator, AnimatorStateInfo animatorStateInfo, int layerIndex)",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -785,7 +875,8 @@
 		"prefix": "OnSceneGUI()",
 		"description": "Enables the Editor to handle an event in the scene view.",
 		"body": [
-			"private void OnSceneGUI() {",
+			"private void OnSceneGUI()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -794,7 +885,8 @@
 		"prefix": "OnFocus()",
 		"description": "Called when the window gets keyboard focus.",
 		"body": [
-			"private void OnFocus() {",
+			"private void OnFocus()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -803,7 +895,8 @@
 		"prefix": "OnHierarchyChange()",
 		"description": "Handler for message that is sent when an object or group of objects in the hierarchy changes.",
 		"body": [
-			"private void OnHierarchyChange() {",
+			"private void OnHierarchyChange()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -812,7 +905,8 @@
 		"prefix": "OnInspectorUpdate()",
 		"description": "OnInspectorUpdate is called at 10 frames per second to give the inspector a chance to update.",
 		"body": [
-			"private void OnInspectorUpdate() {",
+			"private void OnInspectorUpdate()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -821,7 +915,8 @@
 		"prefix": "OnLostFocus()",
 		"description": "Called when the window loses keyboard focus.",
 		"body": [
-			"private void OnLostFocus() {",
+			"private void OnLostFocus()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -830,7 +925,8 @@
 		"prefix": "OnProjectChange()",
 		"description": "Handler for message that is sent whenever the state of the project changes.",
 		"body": [
-			"private void OnProjectChange() {",
+			"private void OnProjectChange()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -839,7 +935,8 @@
 		"prefix": "OnSelectionChange()",
 		"description": "Called whenever the selection has changed.",
 		"body": [
-			"private void OnSelectionChange() {",
+			"private void OnSelectionChange()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -848,7 +945,8 @@
 		"prefix": "OnWizardCreate()",
 		"description": "This is called when the user clicks on the Create button.",
 		"body": [
-			"private void OnWizardCreate() {",
+			"private void OnWizardCreate()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -857,7 +955,8 @@
 		"prefix": "OnWizardOtherButton()",
 		"description": "Allows you to provide an action when the user clicks on the other button.",
 		"body": [
-			"private void OnWizardOtherButton() {",
+			"private void OnWizardOtherButton()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -866,7 +965,8 @@
 		"prefix": "OnWizardUpdate()",
 		"description": "This is called when the wizard is opened or whenever the user changes something in the wizard.",
 		"body": [
-			"private void OnWizardUpdate() {",
+			"private void OnWizardUpdate()",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -910,7 +1010,8 @@
 		"prefix": "class",
 		"description": "Creates a normal class.",
 		"body": [
-			"public class ${TM_FILENAME_BASE} {",
+			"public class ${TM_FILENAME_BASE}",
+			"{",
 			"\t$0",
 			"}"
 		]
@@ -919,7 +1020,8 @@
 		"prefix": "interface",
 		"description": "Creates a normal interface.",
 		"body": [
-			"public interface ${TM_FILENAME_BASE} {",
+			"public interface ${TM_FILENAME_BASE}",
+			"{",
 			"\t$0",
 			"}"
 		]


### PR DESCRIPTION
### What is this?
All snippets have had their opening braces moved to the next line.

### Why was this done?
Unity, as well as C# itself, has a standard convention for braces. This is mentioned [here](https://github.com/a-patel/csharp-style-guide#brace-style) in this C# style guide, which is relevant to Unity as well. Most of Microsoft's documentation also follows this standard, as seen [here](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/inside-a-program/coding-conventions).