### PR TITLE
Added "cs" to package.json snippet languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"contributes": {
 		"snippets": [
 			{
-				"language": "csharp",
+				"language": ["cs", "csharp"],
 				"path": "./snippets/snippets.json"
 			}
 		]


### PR DESCRIPTION
This may be unwanted for your project since it does not affect vscode users. But, since vscode snippets can be used in other editors, such as vim/neovim (my case), it may be useful to some.

When using neovim and the [LuaSnip](https://github.com/L3MON4D3/LuaSnip) plugin, it seems that the snippets are only detected if I add "cs" to the snippet languages in the package.json file, which in this case becomes an array `["cs", "csharp"]`, then all snippets work as expected. 