### PR TITLE
add MonoBehaviour Public Methods snippets and contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,13 @@ Snippets are devided in categories, all of them can be enabled/disabled in the o
    -  `Debug.LogWarningFormat()` (type _`logwarningformat`_)
    -  `Debug.DrawLine()` (type _`drawline`_)
    -  `Debug.DrawRay()` (type _`drawray`_)
+   -  `CancelInvoke()` (type _`cancelinvoke`_)
+   -  `Invoke()` (type _`invoke`_)
+   -  `InvokeRepeating()` (type _`invokerepeating`_)
+   -  `IsInvoking()` (type _`isinvoking`_)
+   -  `StartCoroutine()` (type _`startcoroutine`_)
+   -  `StopAllCoroutines()` (type _`stopallcoroutines`_)
+   -  `StopCoroutine()` (type _`stopcoroutine`_)
 
 -  Attributes:
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,32 @@
 		"email": "kleber.swf@gmail.com",
 		"url": "http://kleber-swf.com"
 	},
+	"contributors": [
+		{
+			"name": "Ferhat TEPE",
+			"url": "https://github.com/Ferhattepe"
+		},
+		{
+			"name": "farukaygun",
+			"url": "https://github.com/farukaygun"
+		},
+		{
+			"name": "dmbfm",
+			"url": "https://github.com/dmbfm"
+		},
+		{
+			"name": "zoosewu",
+			"url": "https://github.com/zoosewu"
+		},
+		{
+			"name": "isnt3174",
+			"url": "https://github.com/isnt3174"
+		},
+		{
+			"name": "TD12734",
+			"url": "https://github.com/TD12734"
+		}
+	],
 	"bugs": {
 		"url": "https://github.com/kleber-swf/vscode-unity-code-snippets/issues",
 		"email": "kleber.swf@gmail.com"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "unity-code-snippets",
 	"displayName": "Unity Code Snippets",
 	"description": "All snippets you need for Unity3D development",
-	"version": "2.4.0",
+	"version": "2.5.0",
 	"publisher": "kleber-swf",
 	"repository": {
 		"type": "git",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -932,6 +932,41 @@
 		"description": "Draws a line from start to start + dir in world coordinates.",
 		"body": "Debug.DrawRay(Vector3 start$1, Vector3 dir$2, Color color = Color.white$3, float duration = 0.0f$4, bool depthTest = true$5);"
 	},
+	"MonoBehaviour CancelInvoke": {
+		"prefix": "CancelInvoke",
+		"description": "Cancels all Invoke calls on this MonoBehaviour.",
+		"body": "CancelInvoke();"
+	},
+	"MonoBehaviour Invoke": {
+		"prefix": "Invoke",
+		"description": "Invokes the method methodName in time seconds.",
+		"body": "Invoke(nameof($1), $2);"
+	},
+	"MonoBehaviour InvokeRepeating": {
+		"prefix": "InvokeRepeating",
+		"description": "Invokes the method methodName in time seconds, then repeatedly every repeatRate seconds.",
+		"body": "InvokeRepeating(nameof($1), $2, $3);"
+	},
+	"MonoBehaviour IsInvoking": {
+		"prefix": "IsInvoking",
+		"description": "Is any invoke on methodName pending?",
+		"body": "IsInvoking(nameof($0));"
+	},
+	"MonoBehaviour StartCoroutine": {
+		"prefix": "StartCoroutine",
+		"description": "Starts a Coroutine.",
+		"body": "StartCoroutine($0);"
+	},
+	"MonoBehaviour StopAllCoroutines": {
+		"prefix": "StopAllCoroutines",
+		"description": "Stops all coroutines running on this behaviour.",
+		"body": "StopAllCoroutines();"
+	},
+	"MonoBehaviour StopCoroutine": {
+		"prefix": "StopCoroutine",
+		"description": "Stops the first coroutine named methodName, or the coroutine stored in routine running on this behaviour.",
+		"body": "StopCoroutine($0);"
+	},
 	"Attribute: SerializeField": {
 		"prefix": "sfield",
 		"body": [

--- a/templates/calls.json
+++ b/templates/calls.json
@@ -51,5 +51,59 @@
 		"prefix": "DrawRay",
 		"description": "Draws a line from start to start + dir in world coordinates.",
 		"body": "Debug.DrawRay(Vector3 start$1, Vector3 dir$2, Color color = Color.white$3, float duration = 0.0f$4, bool depthTest = true$5);"
+	},
+
+	"MonoBehaviour CancelInvoke": {
+		"prefix": "CancelInvoke",
+		"description": "Cancels all Invoke calls on this MonoBehaviour.",
+		"body": "CancelInvoke();"
+	},
+
+	"MonoBehaviour Invoke": {
+		"prefix": "Invoke",
+		"description": "Invokes the method methodName in time seconds.",
+		"body": "Invoke(nameof($1), $2);"
+	},
+
+	"MonoBehaviour InvokeRepeating": {
+		"prefix": "InvokeRepeating",
+		"description": "Invokes the method methodName in time seconds, then repeatedly every repeatRate seconds.",
+		"body": "InvokeRepeating(nameof($1), $2, $3);"
+	},
+
+	"MonoBehaviour IsInvoking": {
+		"prefix": "IsInvoking",
+		"description": "Is any invoke on methodName pending?",
+		"body": "IsInvoking(nameof($0));"
+	},
+
+	"MonoBehaviour StartCoroutine": {
+		"prefix": "StartCoroutine",
+		"description": "Starts a Coroutine.",
+		"body": "StartCoroutine($0);"
+	},
+
+	"MonoBehaviour StopAllCoroutines": {
+		"prefix": "StopAllCoroutines",
+		"description": "Stops all coroutines running on this behaviour.",
+		"body": "StopAllCoroutines();"
+	},
+
+	"MonoBehaviour StopCoroutine": {
+		"prefix": "StopCoroutine",
+		"description": "Stops the first coroutine named methodName, or the coroutine stored in routine running on this behaviour.",
+		"body": "StopCoroutine($0);"
+	},
+
+	"MonoBehaviour a": {
+		"prefix": "a",
+		"description": "a",
+		"body": "a();"
+	},
+
+	"MonoBehaviour i": {
+		"prefix": "a",
+		"description": "a",
+		"body": "a"
 	}
 }

--- a/templates/calls.json
+++ b/templates/calls.json
@@ -93,17 +93,5 @@
 		"prefix": "StopCoroutine",
 		"description": "Stops the first coroutine named methodName, or the coroutine stored in routine running on this behaviour.",
 		"body": "StopCoroutine($0);"
-	},
-
-	"MonoBehaviour a": {
-		"prefix": "a",
-		"description": "a",
-		"body": "a();"
-	},
-
-	"MonoBehaviour i": {
-		"prefix": "a",
-		"description": "a",
-		"body": "a"
 	}
 }


### PR DESCRIPTION
I added the following snippet of [MonoBehaviour](https://docs.unity3d.com/6000.1/Documentation/ScriptReference/MonoBehaviour.html) Public Methods.

-  `CancelInvoke()` (type _`cancelinvoke`_)
-  `Invoke()` (type _`invoke`_)
-  `InvokeRepeating()` (type _`invokerepeating`_)
-  `IsInvoking()` (type _`isinvoking`_)
-  `StartCoroutine()` (type _`startcoroutine`_)
-  `StopAllCoroutines()` (type _`stopallcoroutines`_)
-  `StopCoroutine()` (type _`stopcoroutine`_)

I personally use these functions quite often, so I added them now.

I also added the contributors in package.json.